### PR TITLE
Escape index column names

### DIFF
--- a/src/Database/Vendors/MySQL/MySQLDDLManager.php
+++ b/src/Database/Vendors/MySQL/MySQLDDLManager.php
@@ -210,7 +210,7 @@ class MySQLDDLManager implements DDLManager {
     private function generateCreateIndexSQL(TableIndex $index, string $tableName): string {
         $columnDescriptors = [];
         foreach ($index->getColumns() as $column) {
-            $columnDescriptors[] = $column->getName() . ($column->getMaxBytesToIndex() > 0 ? "(" . $column->getMaxBytesToIndex() . ")" : "");
+            $columnDescriptors[] = "`{$column->getName()}`" . ($column->getMaxBytesToIndex() > 0 ? "(" . $column->getMaxBytesToIndex() . ")" : "");
         }
         return "CREATE INDEX {$index->getName()} ON $tableName (" . join(",", $columnDescriptors) . ")";
     }

--- a/src/Database/Vendors/PostgreSQL/PostgreSQLDDLManager.php
+++ b/src/Database/Vendors/PostgreSQL/PostgreSQLDDLManager.php
@@ -224,7 +224,7 @@ WHERE contype = 'p'
     private function generateCreateIndexSQL(TableIndex $index, string $tableName): string {
         $columnDescriptors = [];
         foreach ($index->getColumns() as $column) {
-            $columnDescriptors[] = $column->getName() . ($column->getMaxBytesToIndex() > 0 ? "(" . $column->getMaxBytesToIndex() . ")" : "");
+            $columnDescriptors[] = "\"{$column->getName()}\"" . ($column->getMaxBytesToIndex() > 0 ? "(" . $column->getMaxBytesToIndex() . ")" : "");
         }
         return "CREATE INDEX {$index->getName()} ON $tableName (" . join(",", $columnDescriptors) . ")";
     }

--- a/src/Database/Vendors/SQLite3/SQLite3DDLManager.php
+++ b/src/Database/Vendors/SQLite3/SQLite3DDLManager.php
@@ -210,7 +210,7 @@ class SQLite3DDLManager implements DDLManager {
     private function generateCreateIndexSQL(TableIndex $index, string $tableName) {
         $columnDescriptors = [];
         foreach ($index->getColumns() as $column) {
-            $columnDescriptors[] = $column->getName() . ($column->getMaxBytesToIndex() > 0 ? "(" . $column->getMaxBytesToIndex() . ")" : "");
+            $columnDescriptors[] = "\"{$column->getName()}\"" . ($column->getMaxBytesToIndex() > 0 ? "(" . $column->getMaxBytesToIndex() . ")" : "");
         }
         return "CREATE INDEX {$index->getName()} ON $tableName (" . join(",", $columnDescriptors) . ")";
     }

--- a/test/Database/Vendors/MySQL/MySQLDDLManagerTest.php
+++ b/test/Database/Vendors/MySQL/MySQLDDLManagerTest.php
@@ -250,7 +250,7 @@ PRIMARY KEY (`id`)
 `description` BLOB NOT NULL,
 `start_date` DATE,
 `last_modified` DATETIME
-);CREATE INDEX name_ind ON test (name);CREATE INDEX score_ind ON test (score,start_date);", $sql);
+);CREATE INDEX name_ind ON test (`name`);CREATE INDEX score_ind ON test (`score`,`start_date`);", $sql);
 
     }
 
@@ -388,7 +388,7 @@ PRIMARY KEY (`id`)
 
         $sql = $this->ddlManager->generateModifyTableSQL($tableAlteration);
 
-        $this->assertEquals("CREATE INDEX new_ind ON test (name);DROP INDEX score_ind ON test;CREATE INDEX score_ind ON test (score,start_date,description);DROP INDEX date_ind ON test;CREATE INDEX date_ind ON test (last_modified,start_date);DROP INDEX name_ind ON test;", $sql);
+        $this->assertEquals("CREATE INDEX new_ind ON test (`name`);DROP INDEX score_ind ON test;CREATE INDEX score_ind ON test (`score`,`start_date`,`description`);DROP INDEX date_ind ON test;CREATE INDEX date_ind ON test (`last_modified`,`start_date`);DROP INDEX name_ind ON test;", $sql);
 
     }
 

--- a/test/Database/Vendors/PostgreSQL/PostgreSQLDDLManagerTest.php
+++ b/test/Database/Vendors/PostgreSQL/PostgreSQLDDLManagerTest.php
@@ -138,7 +138,7 @@ PRIMARY KEY ("id")
 "description" TEXT NOT NULL,
 "start_date" DATE,
 "last_modified" TIMESTAMP
-);CREATE INDEX name_ind ON test (name);CREATE INDEX score_ind ON test (score,start_date);', $sql);
+);CREATE INDEX name_ind ON test ("name");CREATE INDEX score_ind ON test ("score","start_date");', $sql);
 
     }
 
@@ -240,7 +240,7 @@ PRIMARY KEY ("id")
 
         $sql = $this->ddlManager->generateModifyTableSQL($tableAlteration);
 
-        $this->assertEquals("CREATE INDEX new_ind ON test (name);DROP INDEX score_ind;CREATE INDEX score_ind ON test (score,start_date,description);DROP INDEX date_ind;CREATE INDEX date_ind ON test (last_modified,start_date);DROP INDEX name_ind;", $sql);
+        $this->assertEquals('CREATE INDEX new_ind ON test ("name");DROP INDEX score_ind;CREATE INDEX score_ind ON test ("score","start_date","description");DROP INDEX date_ind;CREATE INDEX date_ind ON test ("last_modified","start_date");DROP INDEX name_ind;', $sql);
 
     }
 

--- a/test/Database/Vendors/SQLite3/SQLite3DDLManagerTest.php
+++ b/test/Database/Vendors/SQLite3/SQLite3DDLManagerTest.php
@@ -143,7 +143,7 @@ PRIMARY KEY ("id")
 "description" BLOB NOT NULL,
 "start_date" DATE,
 "last_modified" DATETIME
-);CREATE INDEX name_ind ON test (name);CREATE INDEX score_ind ON test (score,start_date);', $sql);
+);CREATE INDEX name_ind ON test ("name");CREATE INDEX score_ind ON test ("score","start_date");', $sql);
 
     }
 


### PR DESCRIPTION
Escape column names when generating 'create index' sql statements